### PR TITLE
get account transaction improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ NOTE: you need to manually parse cell into dict with 32 bit integer keys.
 
 ### Get account transaction
 ```
-GET /block/<seqno>/<address>/tx/<lt>
+GET /block/<wc>/<shard>/<seqno>/<address>/tx/<lt>
 ```
 ```json
 {

--- a/src/api/handlers/handleAccountTransaction.ts
+++ b/src/api/handlers/handleAccountTransaction.ts
@@ -1,25 +1,32 @@
+import { BN } from 'bn.js';
 import { FastifyRequest, FastifyReply } from 'fastify';
-import { Address } from 'ton';
+import { Address, Builder } from 'ton';
 import { LiteClient } from 'ton-lite-client';
 import { warn } from "../../utils/log";
+
+const buffToInt64Str = (buff: Buffer) => new Builder()
+    .storeBuffer(buff).endCell().beginParse().readInt(64).toString(10);
 
 export function handleAccountTransaction(client: LiteClient) {
     return async (req: FastifyRequest, res: FastifyReply) => {
         try {
-            let params = (req.params as { address: string, lt: string, seqno: string });
-            let address = Address.parse(params.address);
-            let lt = params.lt;
+            let params = (req.params as {
+                wc: string,
+                shard: string,
+                address: string,
+                lt: string,
+                seqno: string
+            });
+
+            const workchain = parseInt(params.wc, 10);
+            const shard = buffToInt64Str(Buffer.from(params.shard, 'hex'));
+            const address = Address.parse(params.address);
             const seqno = parseInt((req.params as any).seqno, 10);
 
-            // Fetch account state
-            let mcInfo = (await client.lookupBlockByID({ seqno: seqno, shard: '-9223372036854775808', workchain: -1 }));
+            let mcinfo = await client.lookupBlockByID({seqno, shard, workchain});
+            let tx = await client.getAccountTransaction(address, params.lt, mcinfo.id);
 
-            // Request
-            let tx = await client.getAccountTransaction(address, lt, mcInfo.id);
-            tx.transaction
-
-            // Result
-            let data = {
+            let data = { // result
                 block: {
                     workchain: tx.id.workchain,
                     shard: tx.id.shard,
@@ -31,7 +38,7 @@ export function handleAccountTransaction(client: LiteClient) {
                 boc: tx.transaction.toString('base64')
             };
 
-            // Return data
+            // return data
             res.status(200)
                 .header('Cache-Control', 'public, max-age=31536000')
                 .send(data);

--- a/src/api/startApi.ts
+++ b/src/api/startApi.ts
@@ -20,7 +20,7 @@ export async function startApi(client: LiteClient, child: { clients: LiteClient[
 
     // Configure
     log('Starting API...');
-    const app = fastify({ 
+    const app = fastify({
         logger: process.env.LOG_ENABLE === 'true',
         maxParamLength: 500,
     });
@@ -46,7 +46,7 @@ export async function startApi(client: LiteClient, child: { clients: LiteClient[
     app.get('/block/:seqno/:address/lite', handleAccountGetLite(client));
     app.get('/block/:seqno/:address/changed/:lt', handleAccountGetChanged(client));
     app.get('/block/:seqno/:address/run/:command/:args?', handleAccountRun(client));
-    app.get('/block/:seqno/:address/tx/:lt', handleAccountTransaction(client));
+    app.get('/block/:wc/:shard/:seqno/:address/tx/:lt', handleAccountTransaction(client));
     app.get('/account/:address/tx/:lt/:hash', handleGetTransactions(client));
 
     // Sending


### PR DESCRIPTION
Pull request with get account transaction improvement. Previously, it was not possible to receive a transaction not from masterchain(-1 workchain), but now but now it's available. `GET /block/<wc>/<shard>/<seqno>/<address>/tx/<lt>`
<img width="983" alt="image with random tx from ton mainnet basechain" src="https://user-images.githubusercontent.com/46900925/210873209-ebd6e52f-84dd-4f8d-bf58-883896f54b34.png">
