### PR TITLE
V42

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,15 @@ import { log } from "./utils/log";
     //
 
     log('Downloading current state....');
-    let mc = await client.main.getMasterchainInfoExt();
+
+    let mc = await client.main.getMasterchainInfoExt().catch(e => {
+        console.error('getMasterchainInfoExt', e);
+    });
+
+    if (!mc) {
+        console.error('getMasterchainInfoExt Failed');
+        return;
+    }
     let blockSync = new BlockSync(mc, client.main);
 
     //
@@ -39,3 +47,9 @@ import { log } from "./utils/log";
 
     await startApi(client.main, client.child, blockSync);
 })();
+
+// catches the exception thrown when trying to connect to a dead liteserver.
+process.on('uncaughtException', function (err) {
+    // Handle the error prevents process exit    
+    console.error('uncaughtException:', err);
+});


### PR DESCRIPTION
this PR comes to solve a problem where the first lite server in the config goes down.
in v41, it throws exception and kills the process. 
In case of restart, the same config will is loaded, first lite server fails again and there is a boot loop.
v42 filters out liteservers which are down during initialisation, and catches unhandled exceptions in case an active liteserver goes down, which happens often on testnet.