### PR TITLE
chore: Rewrited logging

### DIFF
--- a/src/api/handlers/handleAccountGet.ts
+++ b/src/api/handlers/handleAccountGet.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { Address } from '@ton/core';
 import { uint256ToBase64, safeBigIntToNumber } from "../../utils/convert";
 
@@ -90,13 +89,13 @@ export function handleAccountGet(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleAccountGetChanged.ts
+++ b/src/api/handlers/handleAccountGetChanged.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { Address } from '@ton/core';
 
 export function handleAccountGetChanged(client: LiteClient) {
@@ -54,13 +53,13 @@ export function handleAccountGetChanged(client: LiteClient) {
                 });
 
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleAccountGetLite.ts
+++ b/src/api/handlers/handleAccountGetLite.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { Address } from '@ton/core';
 import { uint256ToBase64, safeBigIntToNumber } from "../../utils/convert";
 
@@ -82,13 +81,13 @@ export function handleAccountGetLite(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleAccountRun.ts
+++ b/src/api/handlers/handleAccountRun.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { Address, Cell, parseTuple, TupleItem, serializeTuple } from '@ton/core';
 import { runContract } from '../../executor/runContract';
 import { cellDictionaryToCell } from "../../utils/convert";
@@ -209,13 +208,13 @@ export function handleAccountRun(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetBlock.ts
+++ b/src/api/handlers/handleGetBlock.ts
@@ -9,7 +9,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { Address } from '@ton/core';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 
 export function handleGetBlock(client: LiteClient) {
     return async (req: FastifyRequest, res: FastifyReply) => {
@@ -59,13 +58,13 @@ export function handleGetBlock(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetBlockByTime.ts
+++ b/src/api/handlers/handleGetBlockByTime.ts
@@ -9,7 +9,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { Address } from '@ton/core';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 
 export function handleGetBlockByUtime(client: LiteClient) {
     return async (req: FastifyRequest, res: FastifyReply) => {
@@ -64,13 +63,13 @@ export function handleGetBlockByUtime(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetBlockLatest.ts
+++ b/src/api/handlers/handleGetBlockLatest.ts
@@ -9,7 +9,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
 import { BlockSync } from '../../sync/BlockSync';
-import { log, warn } from "../../utils/log";
 
 export function handleGetBlockLatest(client: LiteClient, blockSync: BlockSync) {
     return async (req: FastifyRequest, res: FastifyReply) => {
@@ -35,13 +34,13 @@ export function handleGetBlockLatest(client: LiteClient, blockSync: BlockSync) {
                     now: mc.lastUtime
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetConfig.ts
+++ b/src/api/handlers/handleGetConfig.ts
@@ -9,7 +9,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { beginCell, Cell, Dictionary } from '@ton/core';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { cellDictionaryToCell, uint256ToAddress } from "../../utils/convert";
 
 export function handleGetConfig(client: LiteClient) {
@@ -75,13 +74,13 @@ export function handleGetConfig(client: LiteClient) {
                     }
                 });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetParsedTransactions.ts
+++ b/src/api/handlers/handleGetParsedTransactions.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 import { ParsedTransaction, rawTransactionToParsedTransaction } from '../../utils/rawTransactionToParsedTransaction';
 import { Address, Cell, loadTransaction } from '@ton/ton';
 
@@ -52,13 +51,13 @@ export function handleGetParsedTransactions(client: LiteClient) {
                 .header('Cache-Control', 'public, max-age=31536000')
                 .send(data);
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleGetTransactions.ts
+++ b/src/api/handlers/handleGetTransactions.ts
@@ -9,7 +9,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { Address } from '@ton/core';
 import { LiteClient } from 'ton-lite-client';
-import { warn } from "../../utils/log";
 
 export function handleGetTransactions(client: LiteClient) {
     return async (req: FastifyRequest, res: FastifyReply) => {
@@ -39,13 +38,13 @@ export function handleGetTransactions(client: LiteClient) {
                 .header('Cache-Control', 'public, max-age=31536000')
                 .send(data);
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .header('Cache-Control', 'public, max-age=1')
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     };

--- a/src/api/handlers/handleSend.ts
+++ b/src/api/handlers/handleSend.ts
@@ -8,7 +8,6 @@
 
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { LiteClient } from "ton-lite-client";
-import { warn } from '../../utils/log';
 import { Address, Cell, loadMessageRelaxed } from '@ton/core';
 
 const EMPTY_ADDRESS = Address.parse('EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c');
@@ -51,12 +50,12 @@ export function handleSend(clients: { clients: LiteClient[] }[]) {
             // Send response
             res.status(200).send({ status: st.status });
         } catch (e) {
-            warn(e);
+            req.log.warn(e);
             try {
                 res.status(500)
                     .send('500 Internal Error');
             } catch (e) {
-                warn(e);
+                req.log.warn(e);
             }
         }
     }


### PR DESCRIPTION
Now we cannot identify failed requests by request-id. This PR makes it possible.